### PR TITLE
Add Dockerfile and GitHub Actions workflow for DockerHub publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+*.Rcheck
+*.tar.gz
+*.Rproj
+README.html
+temp/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,42 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: baynec2/conduitr
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=baynec2/conduitr:buildcache
+          cache-to: type=registry,ref=baynec2/conduitr:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,84 @@
+FROM rocker/bioconductor:latest
+
+# System dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libxml2-dev \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libgit2-dev \
+    libhdf5-dev \
+    libfontconfig1-dev \
+    libharfbuzz-dev \
+    libfribidi-dev \
+    libtiff-dev \
+    libgdal-dev \
+    pandoc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Bioconductor packages
+RUN Rscript -e "BiocManager::install(c( \
+    'QFeatures', \
+    'Biostrings', \
+    'SummarizedExperiment', \
+    'S4Vectors', \
+    'limma', \
+    'MsCoreUtils', \
+    'ComplexHeatmap', \
+    'PCAtools', \
+    'sechm', \
+    'clusterProfiler' \
+), ask = FALSE, update = FALSE)"
+
+# GitHub packages
+RUN Rscript -e "remotes::install_github('grunwaldlab/metacoder')"
+
+# CRAN packages
+RUN Rscript -e "install.packages(c( \
+    'future', \
+    'furrr', \
+    'purrr', \
+    'tibble', \
+    'httr2', \
+    'KEGGREST', \
+    'rentrez', \
+    'XML', \
+    'tidyr', \
+    'dplyr', \
+    'readr', \
+    'stringr', \
+    'ggplot2', \
+    'ggprism', \
+    'ggraph', \
+    'ggkegg', \
+    'tidygraph', \
+    'cowplot', \
+    'viridis', \
+    'heatmaply', \
+    'sunburstR', \
+    'd3r', \
+    'arrow', \
+    'jsonlite', \
+    'glue', \
+    'rlang', \
+    'assertthat', \
+    'httr', \
+    'Matrix', \
+    'xgboost', \
+    'parsnip', \
+    'recipes', \
+    'rsample', \
+    'workflows', \
+    'tune', \
+    'dials', \
+    'hardhat', \
+    'yardstick', \
+    'testthat', \
+    'withr', \
+    'imputeLCMD' \
+), repos = 'https://cloud.r-project.org')"
+
+# Install conduitR from the local source
+COPY . /pkg
+RUN Rscript -e "remotes::install_local('/pkg', dependencies = FALSE)"
+
+CMD ["R"]


### PR DESCRIPTION
Builds and pushes baynec2/conduitr on every push to main, tagged as latest and by git SHA. Uses registry-based layer caching to keep subsequent builds fast.